### PR TITLE
fix: binary example does not run (issue #12)

### DIFF
--- a/examples/binary.js
+++ b/examples/binary.js
@@ -13,7 +13,7 @@ export default function () {
         // Example: Send binary protocol header
         // Format: [0x01, length, ...data]
         const message = "Binary data";
-        const messageBytes = new TextEncoder().encode(message);
+        const messageBytes = Array.from(message).map(c => c.charCodeAt(0));
 
         const packet = new Uint8Array(2 + messageBytes.length);
         packet[0] = 0x01; // Protocol version

--- a/tcp/socket_write.go
+++ b/tcp/socket_write.go
@@ -56,13 +56,13 @@ func (s *socket) writeAsync(data sobek.Value, opts *writeOptions) (*sobek.Promis
 }
 
 func (s *socket) writePrepare(input sobek.Value, opts *writeOptions) ([]byte, *writeOptions, error) {
-	data, err := stringOrArrayBuffer(input, s.vu.Runtime())
-	if err != nil {
-		return nil, nil, err
-	}
-
 	if opts == nil {
 		opts = &writeOptions{}
+	}
+
+	data, err := stringOrArrayBuffer(input, s.vu.Runtime())
+	if err != nil {
+		return nil, opts, err
 	}
 
 	return data, opts, nil

--- a/tcp/socket_write.go
+++ b/tcp/socket_write.go
@@ -137,6 +137,15 @@ func stringOrArrayBuffer(input sobek.Value, runtime *sobek.Runtime) ([]byte, err
 			return nil, err
 		}
 
+	case reflect.TypeFor[sobek.ArrayBuffer]():
+		var ab sobek.ArrayBuffer
+
+		if err := runtime.ExportTo(input, &ab); err != nil {
+			return nil, err
+		}
+
+		data = ab.Bytes()
+
 	default:
 		return nil, fmt.Errorf("%w: String or ArrayBuffer expected", errInvalidType)
 	}


### PR DESCRIPTION
## Summary

Fixes #12 — `examples/binary.js` crashed with `TextEncoder is not defined`, then panicked and failed to send binary data.

- Replace `new TextEncoder().encode()` in `examples/binary.js` with `charCodeAt`-based encoding, since `TextEncoder` is not available in k6's JS runtime
- Fix nil pointer panic in `tcp/socket_write.go`: `writePrepare` returned `nil` opts on error, but the caller immediately dereferenced `opts.Tags`
- Add `sobek.ArrayBuffer` case to `stringOrArrayBuffer` so `socket.write(packet.buffer)` actually works — the API advertised ArrayBuffer support but the type was never handled

Closes #12
Closes #11