### PR TITLE
fix: reject connectAsync promise on connect failures (#20)

### DIFF
--- a/tcp/socket_connect.go
+++ b/tcp/socket_connect.go
@@ -29,24 +29,29 @@ func (co *connectOptions) address() string {
 }
 
 func (s *socket) connectAsync(portOrOptions sobek.Value, hostOrEmpty sobek.Value) (*sobek.Promise, error) {
-	err := s.connectPrepare(portOrOptions, hostOrEmpty)
-	if err != nil {
-		if e := s.handleError(err, "connect", s.tags()); e != nil {
-			return nil, e
+	promise, resolve, reject := promises.New(s.vu)
+
+	if err := s.connectPrepare(portOrOptions, hostOrEmpty); err != nil {
+		tcpErr := s.handleError(err, "connect", s.tags())
+		if tcpErr == nil {
+			tcpErr = newTCPError(err, "connect")
 		}
 
-		return &sobek.Promise{}, nil
-	}
+		reject(tcpErr)
 
-	promise, resolve, reject := promises.New(s.vu)
+		return promise, nil
+	}
 
 	go func() {
 		if err := s.connectExecute(); err != nil {
-			if e := s.handleError(err, "connect", s.tags()); e != nil {
-				reject(e)
-
-				return
+			tcpErr := s.handleError(err, "connect", s.tags())
+			if tcpErr == nil {
+				tcpErr = newTCPError(err, "connect")
 			}
+
+			reject(tcpErr)
+
+			return
 		}
 
 		resolve(nil)

--- a/test/connect-async-error.test.js
+++ b/test/connect-async-error.test.js
@@ -1,0 +1,66 @@
+const fail = require("k6/execution").test.fail
+const assert = (condition, message) => { if (!condition) { fail(message) } }
+
+const tcp = require("k6/x/tcp")
+
+exports.default = async () => {
+  {
+    const socket = new tcp.Socket()
+    let rejected = false
+
+    try {
+      await socket.connectAsync(true)
+    } catch (_) {
+      rejected = true
+    }
+
+    socket.destroy()
+    assert(rejected, "connectAsync should reject on invalid argument type")
+  }
+
+  {
+    const socket = new tcp.Socket()
+    let rejected = false
+
+    try {
+      await socket.connectAsync(0, "127.0.0.1")
+    } catch (_) {
+      rejected = true
+    }
+
+    socket.destroy()
+    assert(rejected, "connectAsync should reject on connection failure")
+  }
+
+  {
+    const socket = new tcp.Socket()
+    let rejected = false
+
+    socket.on("error", () => {})
+
+    try {
+      await socket.connectAsync(0, "127.0.0.1")
+    } catch (_) {
+      rejected = true
+    }
+
+    socket.destroy()
+    assert(rejected, "connectAsync should reject on connection failure even with an error handler")
+  }
+
+  {
+    const socket = new tcp.Socket()
+    let rejected = false
+
+    socket.on("error", () => {})
+
+    try {
+      await socket.connectAsync(true)
+    } catch (_) {
+      rejected = true
+    }
+
+    socket.destroy()
+    assert(rejected, "connectAsync should reject on invalid argument type even with an error handler")
+  }
+}


### PR DESCRIPTION
## Summary
- make `connectAsync()` always return a real Promise
- reject prepare-time failures instead of returning an empty Promise
- reject execute-time failures even when an `error` handler is registered
- add regression coverage for both failure modes with and without an `error` handler