### PR TITLE
feat: implement documented write encodings (#21)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ const socket = new Socket(options);
 | `on(event, handler)` | Registers an event handler
 
 **Write Options:**
-- `encoding` (optional): Encoding for string data (e.g., 'utf8', 'base64', 'hex')
+- `encoding` (optional): For string data, supports `utf8`, `utf-8`, `ascii`, `base64`, `base64url`, and `hex`; unsupported values are rejected. Ignored for `ArrayBuffer` input.
 - `tags` (optional): Key-value pairs for write-specific metrics
 
 ### Properties

--- a/index.d.ts
+++ b/index.d.ts
@@ -161,12 +161,13 @@ declare module "k6/x/tcp" {
      * The encoding to use when data is a string.
      * 
      * Supported encodings:
-     * - `'utf8'` (default): Standard UTF-8 text encoding
-     * - `'ascii'`: 7-bit ASCII encoding
-     * - `'base64'`: Base64-encoded data
-     * - `'hex'`: Hexadecimal string representation
-     * - And other encodings supported by Go's encoding package
+     * - `'utf8'` / `'utf-8'` (default): UTF-8 text encoding
+     * - `'ascii'`: Raw byte conversion for write operations
+     * - `'base64'`: Base64-encoded data decoded to bytes before sending
+     * - `'base64url'`: URL-safe Base64 decoded to bytes before sending
+     * - `'hex'`: Hexadecimal string decoded to bytes before sending
      * 
+     * Unsupported values are rejected.
      * When writing an ArrayBuffer, this option is ignored.
      */
     encoding?: string;

--- a/tcp/socket_error_test.go
+++ b/tcp/socket_error_test.go
@@ -94,7 +94,7 @@ func TestStringOrArrayBufferWithString(t *testing.T) {
 	mod := newTestModuleInstance(t)
 
 	input := mod.vu.Runtime().ToValue("Hello, World!")
-	data, err := stringOrArrayBuffer(input, mod.vu.Runtime())
+	data, err := stringOrArrayBuffer(input, "", mod.vu.Runtime())
 
 	require.NoError(t, err)
 	require.Equal(t, []byte("Hello, World!"), data)
@@ -107,7 +107,7 @@ func TestStringOrArrayBufferWithBytes(t *testing.T) {
 
 	expected := []byte{0x01, 0x02, 0x03, 0x04}
 	input := mod.vu.Runtime().ToValue(expected)
-	data, err := stringOrArrayBuffer(input, mod.vu.Runtime())
+	data, err := stringOrArrayBuffer(input, "", mod.vu.Runtime())
 
 	require.NoError(t, err)
 	require.Equal(t, expected, data)
@@ -120,7 +120,7 @@ func TestStringOrArrayBufferWithInvalidType(t *testing.T) {
 
 	// Test with number
 	input := mod.vu.Runtime().ToValue(123)
-	_, err := stringOrArrayBuffer(input, mod.vu.Runtime())
+	_, err := stringOrArrayBuffer(input, "", mod.vu.Runtime())
 
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "String or ArrayBuffer expected")

--- a/tcp/socket_write.go
+++ b/tcp/socket_write.go
@@ -1,9 +1,12 @@
 package tcp
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
+	"strings"
 	"sync/atomic"
 
 	"github.com/grafana/sobek"
@@ -11,8 +14,9 @@ import (
 )
 
 var (
-	errNoActiveConnection = errors.New("no active connection")
-	errWrite0Bytes        = errors.New("write returned 0 bytes written")
+	errNoActiveConnection  = errors.New("no active connection")
+	errUnsupportedEncoding = errors.New("unsupported encoding")
+	errWrite0Bytes         = errors.New("write returned 0 bytes written")
 )
 
 type writeOptions struct {
@@ -21,12 +25,19 @@ type writeOptions struct {
 }
 
 func (s *socket) writeAsync(data sobek.Value, opts *writeOptions) (*sobek.Promise, error) {
+	promise, resolve, reject := promises.New(s.vu)
+
 	dataBytes, opts, err := s.writePrepare(data, opts)
 	if err != nil {
-		return nil, err
-	}
+		tcpErr := s.handleError(err, "write", addToTagSet(s.currentTags(), opts.Tags))
+		if tcpErr == nil {
+			tcpErr = newTCPError(err, "write")
+		}
 
-	promise, resolve, reject := promises.New(s.vu)
+		reject(tcpErr)
+
+		return promise, nil
+	}
 
 	go func() {
 		err := s.writeExecute(dataBytes, opts)
@@ -47,7 +58,7 @@ func (s *socket) writePrepare(input sobek.Value, opts *writeOptions) ([]byte, *w
 		opts = &writeOptions{}
 	}
 
-	data, err := stringOrArrayBuffer(input, s.vu.Runtime())
+	data, err := stringOrArrayBuffer(input, opts.Encoding, s.vu.Runtime())
 	if err != nil {
 		return nil, opts, err
 	}
@@ -106,9 +117,7 @@ func (s *socket) writeExecute(data []byte, opts *writeOptions) error {
 	return result
 }
 
-func stringOrArrayBuffer(input sobek.Value, runtime *sobek.Runtime) ([]byte, error) {
-	var data []byte
-
+func stringOrArrayBuffer(input sobek.Value, encoding string, runtime *sobek.Runtime) ([]byte, error) {
 	switch input.ExportType() {
 	case reflect.TypeFor[string]():
 		var str string
@@ -117,12 +126,16 @@ func stringOrArrayBuffer(input sobek.Value, runtime *sobek.Runtime) ([]byte, err
 			return nil, err
 		}
 
-		data = []byte(str)
+		return decodeString(str, encoding)
 
 	case reflect.TypeFor[[]byte]():
+		var data []byte
+
 		if err := runtime.ExportTo(input, &data); err != nil {
 			return nil, err
 		}
+
+		return data, nil
 
 	case reflect.TypeFor[sobek.ArrayBuffer]():
 		var ab sobek.ArrayBuffer
@@ -131,11 +144,33 @@ func stringOrArrayBuffer(input sobek.Value, runtime *sobek.Runtime) ([]byte, err
 			return nil, err
 		}
 
-		data = ab.Bytes()
+		return ab.Bytes(), nil
 
 	default:
 		return nil, fmt.Errorf("%w: String or ArrayBuffer expected", errInvalidType)
 	}
+}
 
-	return data, nil
+func decodeString(s, encoding string) ([]byte, error) {
+	switch strings.ToLower(encoding) {
+	case "", "utf8", "utf-8", "ascii":
+		return []byte(s), nil
+	case "base64":
+		return base64.StdEncoding.DecodeString(s)
+	case "base64url":
+		return decodeBase64URLString(s)
+	case "hex":
+		return hex.DecodeString(s)
+	default:
+		return nil, fmt.Errorf("%w %q", errUnsupportedEncoding, encoding)
+	}
+}
+
+func decodeBase64URLString(s string) ([]byte, error) {
+	data, err := base64.RawURLEncoding.DecodeString(s)
+	if err == nil {
+		return data, nil
+	}
+
+	return base64.URLEncoding.DecodeString(s)
 }

--- a/test/write-encoding.test.js
+++ b/test/write-encoding.test.js
@@ -1,0 +1,107 @@
+const fail = require("k6/execution").test.fail
+const assert = (condition, message) => { if (!condition) { fail(message) } }
+
+const tcp = require("k6/x/tcp")
+
+const bytesToString = (data) => String.fromCharCode.apply(null, new Uint8Array(data))
+
+async function expectEchoed(encoded, options, expected) {
+  const socket = new tcp.Socket()
+  let received = false
+
+  socket.on("data", (data) => {
+    received = true
+
+    const actual = bytesToString(data)
+    assert(actual === expected, `expected '${expected}', got '${actual}'`)
+    socket.destroy()
+  })
+
+  socket.on("error", (err) => {
+    fail(`unexpected socket error: ${err}`)
+  })
+
+  const closed = new Promise((resolve) => {
+    socket.on("close", () => {
+      resolve()
+    })
+  })
+
+  await socket.connectAsync(__ENV.TCP_ECHO_PORT, __ENV.TCP_ECHO_HOST)
+  await socket.writeAsync(encoded, options)
+  await closed
+
+  assert(received, "data handler was not called")
+}
+
+async function expectWriteRejected(data, options, registerErrorHandler) {
+  const socket = new tcp.Socket()
+  let rejected = false
+  let errorFired = false
+  let errorPromise = Promise.resolve()
+
+  if (registerErrorHandler) {
+    errorPromise = new Promise((resolve) => {
+      socket.on("error", () => {
+        errorFired = true
+        resolve()
+      })
+    })
+  }
+
+  try {
+    await socket.writeAsync(data, options)
+  } catch (_) {
+    rejected = true
+  }
+
+  await errorPromise
+  socket.destroy()
+
+  assert(rejected, "writeAsync should reject")
+  if (registerErrorHandler) {
+    assert(errorFired, "error handler was not called")
+  }
+}
+
+exports.default = async () => {
+  await expectEchoed("Hello", {}, "Hello")
+  await expectEchoed("Hello", { encoding: "utf8" }, "Hello")
+  await expectEchoed("Hello", { encoding: "utf-8" }, "Hello")
+  await expectEchoed("Hello", { encoding: "ascii" }, "Hello")
+  await expectEchoed("SGVsbG8=", { encoding: "base64" }, "Hello")
+  await expectEchoed("SGVsbG8", { encoding: "base64url" }, "Hello")
+  await expectEchoed("SGVsbG8=", { encoding: "base64url" }, "Hello")
+  await expectEchoed("48656c6c6f", { encoding: "hex" }, "Hello")
+
+  {
+    const socket = new tcp.Socket()
+    let received = false
+
+    socket.on("data", (data) => {
+      received = true
+      assert(bytesToString(data) === "Hello", `expected 'Hello', got '${bytesToString(data)}'`)
+      socket.destroy()
+    })
+
+    socket.on("error", (err) => {
+      fail(`unexpected socket error: ${err}`)
+    })
+
+    const closed = new Promise((resolve) => {
+      socket.on("close", () => {
+        resolve()
+      })
+    })
+
+    await socket.connectAsync(__ENV.TCP_ECHO_PORT, __ENV.TCP_ECHO_HOST)
+    await socket.writeAsync(new Uint8Array([72, 101, 108, 108, 111]).buffer, { encoding: "hex" })
+    await closed
+
+    assert(received, "ArrayBuffer data handler was not called")
+  }
+
+  await expectWriteRejected("Hello", { encoding: "latin1" }, true)
+  await expectWriteRejected("not!!base64", { encoding: "base64" }, false)
+  await expectWriteRejected("zzzz", { encoding: "hex" }, false)
+}


### PR DESCRIPTION
## Summary
- implement the documented `WriteOptions.encoding` behavior for string writes
- support `utf8`, `utf-8`, `ascii`, `base64`, `base64url`, and `hex`
- reject unsupported encodings predictably
- keep `ArrayBuffer` writes on the raw-byte path
- include the inseparable prepare-time `writeAsync()` Promise fix for unsupported encoding errors
- add focused regression coverage for encoding behavior
- update `index.d.ts` and README to match the supported encoding set