### PR TITLE
fix: stop read loop on fatal read errors (#22)

### DIFF
--- a/tcp/socket_read.go
+++ b/tcp/socket_read.go
@@ -89,5 +89,5 @@ func (s *socket) readLoopStep(conn net.Conn, timeout time.Duration) bool {
 		s.log.WithError(e).Error("error in error handler")
 	}
 
-	return true
+	return false
 }

--- a/tcp/socket_read_test.go
+++ b/tcp/socket_read_test.go
@@ -1,0 +1,119 @@
+package tcp
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.k6.io/k6/js/modulestest"
+	"go.k6.io/k6/lib"
+	"go.k6.io/k6/metrics"
+)
+
+var errConnectionResetByPeer = errors.New("connection reset by peer")
+
+func newRunningModuleInstance(t *testing.T) *module {
+	t.Helper()
+
+	runtime := modulestest.NewRuntime(t)
+	root := new(rootModule)
+	moduleInstance := root.NewModuleInstance(runtime.VU)
+
+	mod, ok := moduleInstance.(*module)
+	if !ok {
+		t.Fatalf("failed to assert module instance")
+	}
+
+	registry := runtime.VU.InitEnvField.Registry
+	runtime.MoveToVUContext(&lib.State{
+		Samples: make(chan metrics.SampleContainer, 1000),
+		Tags:    lib.NewVUStateTags(registry.RootTagSet()),
+	})
+
+	return mod
+}
+
+type stubConn struct {
+	net.Conn
+
+	readErr error
+}
+
+func (c *stubConn) Read(_ []byte) (int, error)        { return 0, c.readErr }
+func (c *stubConn) SetReadDeadline(_ time.Time) error { return nil }
+func (c *stubConn) Close() error                      { return nil }
+
+type timeoutError struct{}
+
+func (e *timeoutError) Error() string   { return "i/o timeout" }
+func (e *timeoutError) Timeout() bool   { return true }
+func (e *timeoutError) Temporary() bool { return true }
+
+func TestReadLoopStepFatalErrorReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	mod := newRunningModuleInstance(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+	_, cancel := context.WithCancel(mod.vu.Context())
+	s.cancel = cancel
+	s.state = socketStateOpen
+
+	conn := &stubConn{readErr: errConnectionResetByPeer}
+	require.False(t, s.readLoopStep(conn, 0))
+}
+
+func TestReadLoopStepEOFReturnsFalse(t *testing.T) {
+	t.Parallel()
+
+	mod := newTestModuleInstance(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+	_, cancel := context.WithCancel(mod.vu.Context())
+	s.cancel = cancel
+	s.state = socketStateOpen
+
+	conn := &stubConn{readErr: io.EOF}
+	require.False(t, s.readLoopStep(conn, 0))
+}
+
+func TestReadLoopStepTimeoutReturnsTrue(t *testing.T) {
+	t.Parallel()
+
+	mod := newTestModuleInstance(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+	_, cancel := context.WithCancel(mod.vu.Context())
+	s.cancel = cancel
+	s.state = socketStateOpen
+
+	conn := &stubConn{readErr: &net.OpError{Op: "read", Err: &timeoutError{}}}
+	require.True(t, s.readLoopStep(conn, 0))
+}
+
+func TestFatalReadErrorDestroysSocket(t *testing.T) {
+	t.Parallel()
+
+	mod := newRunningModuleInstance(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+	s.socketOpts = new(socketOptions)
+
+	ctx, cancel := context.WithCancel(mod.vu.Context())
+	s.cancel = cancel
+
+	go s.loop(ctx)
+
+	s.state = socketStateOpen
+	s.conn = &stubConn{readErr: errConnectionResetByPeer}
+
+	go s.read()
+
+	require.Eventually(t, func() bool {
+		s.mu.RLock()
+		state := s.state
+		s.mu.RUnlock()
+
+		return state == socketStateDestroyed
+	}, time.Second, time.Millisecond)
+}


### PR DESCRIPTION
## Summary
- stop the read loop on fatal non-timeout read errors
- keep EOF as a clean terminal condition
- keep timeout as a non-terminal condition
- ensure the socket does not remain stuck in `open` state after a fatal read failure
- add focused regression coverage for fatal, EOF, timeout, and cleanup behavior