### PR TITLE
docs: align public API types with runtime behavior (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Register event handlers for connection lifecycle and data events using the `.on(
 |-------------|------------------------------------------------------------------
 | `connect`   | Triggered when the socket successfully establishes a connection to the remote server
 | `data`      | Triggered when data is received from the remote endpoint
-| `close`     | Triggered when the socket connection is fully closed (receives `hadError` boolean)
+| `close`     | Triggered when the socket connection is fully closed
 | `error`     | Triggered when a socket error occurs (connection failures, network issues, etc.)
 | `timeout`   | Triggered when the socket times out due to inactivity (see `setTimeout()`)
 
@@ -109,7 +109,7 @@ const socket = new Socket(options);
 | `connectAsync(options)` | Async version with options
 | `writeAsync(data, options?)` | Async version that returns a Promise
 | `setTimeout(timeout)` | Sets inactivity timeout in milliseconds (0 to disable)
-| `destroy(error?)` | Destroys the socket and closes the connection
+| `destroy()` | Destroys the socket and closes the connection
 | `on(event, handler)` | Registers an event handler
 
 **Write Options:**

--- a/index.d.ts
+++ b/index.d.ts
@@ -97,8 +97,8 @@ declare module "k6/x/tcp" {
    * ```
    */
   export interface ConnectOptions {
-    /** The destination port number (1-65535) */
-    port: number;
+    /** The destination port number or numeric string (1-65535) */
+    port: number | string;
     /** The destination hostname or IP address. Defaults to 'localhost' */
     host?: string;
     /**
@@ -336,7 +336,7 @@ declare module "k6/x/tcp" {
      * or rejects on connection failure. This is useful for sequential operations
      * where you need to ensure the connection is ready before proceeding.
      * 
-     * @param port The destination port number (1-65535)
+     * @param port The destination port number or numeric string (1-65535)
      * @param host The destination hostname or IP address. Defaults to 'localhost'
      * @returns A Promise that resolves when connected successfully
      * @example
@@ -350,7 +350,7 @@ declare module "k6/x/tcp" {
      * }
      * ```
      */
-    connectAsync(port: number, host?: string): Promise<void>;
+    connectAsync(port: number | string, host?: string): Promise<void>;
 
     /**
      * Asynchronously establishes a TCP connection using detailed options.
@@ -404,19 +404,11 @@ declare module "k6/x/tcp" {
      * 
      * Once destroyed, the socket cannot be reused. All pending operations will
      * be terminated and a 'close' event will be emitted.
-     * 
-     * If an error is provided, an 'error' event will be emitted before closing.
-     * 
-     * @param error Optional error to emit before closing the socket
-     * @returns The socket itself for method chaining
      * @example
      * ```typescript
      * // Clean shutdown
      * socket.destroy();
-     * 
-     * // Destroy with error
-     * socket.destroy(new Error('Connection timeout'));
-     * 
+     *
      * // Common pattern: destroy after data received
      * socket.on('data', (data) => {
      *   processData(data);
@@ -424,7 +416,7 @@ declare module "k6/x/tcp" {
      * });
      * ```
      */
-    destroy(error?: Error): this;
+    destroy(): void;
 
     /**
      * Sets the socket timeout for inactivity.
@@ -465,7 +457,6 @@ declare module "k6/x/tcp" {
      *
      * @param event The event name 'connect'
      * @param listener Callback function invoked when the connection is established
-     * @returns The socket instance for method chaining
      * @example
      * ```typescript
      * socket.on('connect', () => {
@@ -474,7 +465,7 @@ declare module "k6/x/tcp" {
      * });
      * ```
      */
-    on(event: 'connect', listener: () => void): this;
+    on(event: 'connect', listener: () => void): void;
 
     /**
      * Registers an event listener for the 'data' event.
@@ -487,7 +478,6 @@ declare module "k6/x/tcp" {
      *
      * @param event The event name 'data'
      * @param listener Callback function invoked when data is received
-     * @returns The socket instance for method chaining
      * @example
      * ```typescript
      * socket.on('data', (data) => {
@@ -499,7 +489,7 @@ declare module "k6/x/tcp" {
      * });
      * ```
      */
-    on(event: 'data', listener: (data: Uint8Array) => void): this;
+    on(event: 'data', listener: (data: Uint8Array) => void): void;
 
     /**
      * Registers an event listener for the 'close' event.
@@ -516,7 +506,6 @@ declare module "k6/x/tcp" {
      *
      * @param event The event name 'close'
      * @param listener Callback function invoked when the socket closes
-     * @returns The socket instance for method chaining
      * @example
      * ```typescript
      * // Basic usage
@@ -533,7 +522,7 @@ declare module "k6/x/tcp" {
      * await closePromise; // Wait for connection to close
      * ```
      */
-    on(event: 'close', listener: () => void): this;
+    on(event: 'close', listener: () => void): void;
 
     /**
      * Registers an event listener for the 'error' event.
@@ -547,7 +536,6 @@ declare module "k6/x/tcp" {
      *
      * @param event The event name 'error'
      * @param listener Callback function invoked when an error occurs, receives the Error object
-     * @returns The socket instance for method chaining
      * @example
      * ```typescript
      * socket.on('error', (error) => {
@@ -557,7 +545,7 @@ declare module "k6/x/tcp" {
      * });
      * ```
      */
-    on(event: 'error', listener: (error: Error) => void): this;
+    on(event: 'error', listener: (error: Error) => void): void;
 
     /**
      * Registers an event listener for the 'timeout' event.
@@ -571,7 +559,6 @@ declare module "k6/x/tcp" {
      *
      * @param event The event name 'timeout'
      * @param listener Callback function invoked when the socket times out
-     * @returns The socket instance for method chaining
      * @example
      * ```typescript
      * socket.setTimeout(30000); // Set 30-second timeout
@@ -581,6 +568,6 @@ declare module "k6/x/tcp" {
      * });
      * ```
      */
-    on(event: 'timeout', listener: () => void): this;
+    on(event: 'timeout', listener: () => void): void;
   }
 }

--- a/test/api-align.test.js
+++ b/test/api-align.test.js
@@ -1,0 +1,49 @@
+const fail = require("k6/execution").test.fail
+const assert = (condition, message) => { if (!condition) { fail(message) } }
+
+const tcp = require("k6/x/tcp")
+
+async function expectStringPortAccepted(connectCall, label) {
+  const socket = new tcp.Socket()
+  let rejected = false
+  let errorText = ""
+
+  try {
+    await connectCall(socket)
+  } catch (err) {
+    rejected = true
+    errorText = String(err)
+  }
+
+  socket.destroy()
+
+  assert(rejected, `${label} should reject on connection failure`)
+  assert(!errorText.includes("invalid type"), `${label} should not fail type validation: ${errorText}`)
+}
+
+exports.default = async () => {
+  {
+    const socket = new tcp.Socket()
+    const result = socket.on("connect", () => {})
+
+    assert(result === undefined, `on() should return undefined, got ${result}`)
+    socket.destroy()
+  }
+
+  {
+    const socket = new tcp.Socket()
+    const result = socket.destroy()
+
+    assert(result === undefined, `destroy() should return undefined, got ${result}`)
+  }
+
+  await expectStringPortAccepted(
+    (socket) => socket.connectAsync("0", "127.0.0.1"),
+    "connectAsync(port: string, host)",
+  )
+
+  await expectStringPortAccepted(
+    (socket) => socket.connectAsync({ port: "0", host: "127.0.0.1" }),
+    "connectAsync({ port: string, host })",
+  )
+}


### PR DESCRIPTION
## Summary
- align `index.d.ts` with the current async-only runtime behavior
- accept string ports in `connectAsync()` typings and `ConnectOptions`
- remove stale `destroy(error?)` and chaining typings
- document `on()` as returning `undefined` instead of the socket
- fix README API and event descriptions to match runtime behavior
- add focused async-only API-alignment coverage
