### PR TITLE
fix: make socket event ordering deterministic (#24)

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     "ghcr.io/devcontainers/features/github-cli:1": { "version": "2.72.0" },
     "ghcr.io/devcontainers/features/go:1": {
       "version": "1.26",
-      "golangciLintVersion": "2.4.0"
+      "golangciLintVersion": "2.11.4"
     },
     "ghcr.io/guiyomh/features/gotestsum:0": { "version": "1.12.1" },
     "ghcr.io/michidk/devcontainers-features/bun:1": { "version": "1.2.12" },

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": { "version": "2.72.0" },
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.25",
+      "version": "1.26",
       "golangciLintVersion": "2.4.0"
     },
     "ghcr.io/guiyomh/features/gotestsum:0": { "version": "1.12.1" },

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,9 +13,9 @@ jobs:
     permissions:
       contents: write
     with:
-      go-version: "1.25.x"
+      go-version: "1.26.x"
       os: '["linux", "windows", "darwin"]'
       arch: '["amd64", "arm64"]'
-      k6-version: "v1.6.1"
-      xk6-version: "1.3.5"
+      k6-version: "v1.7.1"
+      xk6-version: "1.3.7"
       private: true

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,9 +5,9 @@ permissions: {}
 on:
   workflow_dispatch:
   push:
-    branches: ["main", "master"]
+    branches: [ "main", "master" ]
   pull_request:
-    branches: ["main", "master"]
+    branches: [ "main", "master" ]
 
 jobs:
   validate:
@@ -19,8 +19,8 @@ jobs:
       contents: read
     with:
       go-version: "1.26.x"
-      go-versions: '["1.26.x"]'
-      golangci-lint-version: "v2.4.0"
-      platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      k6-versions: '["v1.7.1"]'
+      go-versions: "[\"1.26.x\"]"
+      golangci-lint-version: "v2.11.4"
+      platforms: "[\"ubuntu-latest\", \"windows-latest\", \"macos-latest\"]"
+      k6-versions: "[\"v1.7.1\"]"
       xk6-version: "1.3.7"

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -18,9 +18,9 @@ jobs:
       id-token: write
       contents: read
     with:
-      go-version: "1.25.x"
-      go-versions: '["1.25.x"]'
+      go-version: "1.26.x"
+      go-versions: '["1.26.x"]'
       golangci-lint-version: "v2.4.0"
       platforms: '["ubuntu-latest", "windows-latest", "macos-latest"]'
-      k6-versions: '["v1.6.1"]'
-      xk6-version: "1.3.5"
+      k6-versions: '["v1.7.1"]'
+      xk6-version: "1.3.7"

--- a/internal/echo/server.go
+++ b/internal/echo/server.go
@@ -49,11 +49,11 @@ func Setup() *Server {
 
 	server, err := New()
 	if err != nil {
-		slog.Error("Error starting embedded echo server: ", "error", err)
+		panic(fmt.Errorf("failed to start embedded echo server: %w", err))
 	}
 
 	if err := server.Setenv(); err != nil {
-		slog.Error("Error setting up environment variables: ", "error", err)
+		panic(fmt.Errorf("failed to set up embedded echo server environment: %w", err))
 	}
 
 	server.Start()

--- a/tcp/socket_connect.go
+++ b/tcp/socket_connect.go
@@ -122,11 +122,11 @@ func (s *socket) connectExecute() error {
 	// Release mutex before firing events and starting read goroutine
 	s.mu.Unlock()
 
-	// Start read goroutine
-	go s.read()
-
-	// Fire connect event
+	// Queue connect before the read goroutine can enqueue later lifecycle events.
 	s.fire("connect")
+
+	// Start read goroutine after connect has been queued.
+	go s.read()
 
 	s.addCounterMetrics(s.metrics.tcpSockets, tags)
 
@@ -237,12 +237,6 @@ func (s *socket) destroy() {
 
 		// Fire close event
 		s.fire("close")
-
-		// Wait briefly for the close event goroutine to queue the callback
-		// before cancelling the context. This ensures the event loop processes
-		// the close event before shutting down. Without this, there's a race
-		// where cancel() stops the event loop before fire() can queue the event.
-		time.Sleep(1 * time.Millisecond)
 
 		// Cancel context to signal loops to stop
 		s.cancel()

--- a/tcp/socket_dispatch_test.go
+++ b/tcp/socket_dispatch_test.go
@@ -1,0 +1,112 @@
+package tcp
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/sobek"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFireBlocksUntilLoopReceivesCallback(t *testing.T) {
+	t.Parallel()
+
+	mod := newRunningModuleInstance(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+
+	handler := mod.vu.Runtime().ToValue(func() {})
+	callable, ok := sobek.AssertFunction(handler)
+	require.True(t, ok)
+
+	s.on("connect", callable)
+
+	queued := make(chan struct{})
+
+	go func() {
+		s.fire("connect")
+		close(queued)
+	}()
+
+	require.Never(t, func() bool {
+		select {
+		case <-queued:
+			return true
+		default:
+			return false
+		}
+	}, 50*time.Millisecond, time.Millisecond)
+
+	go func() {
+		callback := <-s.callChan
+		_ = callback()
+	}()
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-queued:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+}
+
+func TestFirePreservesEventOrder(t *testing.T) {
+	t.Parallel()
+
+	mod := newRunningModuleInstance(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+
+	var (
+		mu     sync.Mutex
+		events []string
+	)
+
+	record := func(name string) {
+		mu.Lock()
+		defer mu.Unlock()
+
+		events = append(events, name)
+	}
+
+	connectHandler := mod.vu.Runtime().ToValue(func() {
+		record("connect")
+	})
+	connectCallable, ok := sobek.AssertFunction(connectHandler)
+	require.True(t, ok)
+
+	closeHandler := mod.vu.Runtime().ToValue(func() {
+		record("close")
+	})
+	closeCallable, ok := sobek.AssertFunction(closeHandler)
+	require.True(t, ok)
+
+	s.on("connect", connectCallable)
+	s.on("close", closeCallable)
+
+	done := make(chan struct{})
+
+	go func() {
+		defer close(done)
+
+		for range 2 {
+			callback := <-s.callChan
+			_ = callback()
+		}
+	}()
+
+	s.fire("connect")
+	s.fire("close")
+
+	require.Eventually(t, func() bool {
+		select {
+		case <-done:
+			return true
+		default:
+			return false
+		}
+	}, time.Second, time.Millisecond)
+
+	require.Equal(t, []string{"connect", "close"}, events)
+}

--- a/tcp/socket_on.go
+++ b/tcp/socket_on.go
@@ -60,37 +60,36 @@ func (s *socket) fireAndCleanup(cleanup func(), event string, args ...any) bool 
 
 	s.log.WithField("event", event).Debug("Queuing event handler")
 
-	// Queue the event asynchronously to prevent deadlock when firing events from within event handlers
-	go func() {
-		select {
-		case s.callChan <- func() error {
-			if cleanup != nil {
-				defer cleanup()
-			}
-
-			s.log.WithField("event", event).Debug("Firing event handler")
-
-			// Convert raw Go values to sobek.Value in the event loop
-			sobekArgs := make([]sobek.Value, len(args))
-			for i, arg := range args {
-				sobekArgs[i] = s.vu.Runtime().ToValue(arg)
-			}
-
-			_, err := fn(sobek.Undefined(), sobekArgs...)
-
-			return err
-		}:
-
-		case <-s.vu.Context().Done():
-			s.log.WithField("event", event).Debug("Context cancelled, skipping event")
-
-			if cleanup != nil {
-				cleanup()
-			}
+	// Queue synchronously so the caller's event order is preserved across goroutines.
+	select {
+	case s.callChan <- func() error {
+		if cleanup != nil {
+			defer cleanup()
 		}
-	}()
 
-	return true
+		s.log.WithField("event", event).Debug("Firing event handler")
+
+		// Convert raw Go values to sobek.Value in the event loop
+		sobekArgs := make([]sobek.Value, len(args))
+		for i, arg := range args {
+			sobekArgs[i] = s.vu.Runtime().ToValue(arg)
+		}
+
+		_, err := fn(sobek.Undefined(), sobekArgs...)
+
+		return err
+	}:
+		return true
+
+	case <-s.vu.Context().Done():
+		s.log.WithField("event", event).Debug("Context cancelled, skipping event")
+
+		if cleanup != nil {
+			cleanup()
+		}
+
+		return false
+	}
 }
 
 func (s *socket) handleError(err error, method string, ts *metrics.TagSet) error {

--- a/test/connect-async.test.js
+++ b/test/connect-async.test.js
@@ -23,14 +23,11 @@ exports.default = async () => {
     })
   })
 
-  prom.then(() => {
-    assert(connectHandlerCalled, "connect handler was not called")
-    assert(closeHandlerCalled, "close handler was not called")
-  })
-
   assert(!socket.connected, "socket should not be connected initially")
 
   await socket.connectAsync(__ENV.TCP_ECHO_PORT, __ENV.TCP_ECHO_HOST)
+  await prom
 
-  assert(socket.connected, "socket should be connected after connect call")
+  assert(connectHandlerCalled, "connect handler was not called")
+  assert(closeHandlerCalled, "close handler was not called")
 }

--- a/test/event-order.test.js
+++ b/test/event-order.test.js
@@ -1,0 +1,47 @@
+const fail = require("k6/execution").test.fail
+const assert = (condition, message) => { if (!condition) { fail(message) } }
+
+const tcp = require("k6/x/tcp")
+
+exports.default = async () => {
+  const socket = new tcp.Socket({})
+  const events = []
+  let sawData = false
+
+  const closed = new Promise((resolve) => {
+    socket.on("close", () => {
+      events.push("close")
+      resolve()
+    })
+  })
+
+  socket.on("connect", () => {
+    events.push("connect")
+  })
+
+  socket.on("data", () => {
+    if (sawData) {
+      return
+    }
+
+    sawData = true
+    events.push("data")
+    socket.destroy()
+  })
+
+  socket.on("error", (err) => {
+    fail(`unexpected socket error: ${err}`)
+  })
+
+  await socket.connectAsync(__ENV.TCP_ECHO_PORT, __ENV.TCP_ECHO_HOST)
+  await socket.writeAsync("event order")
+  await closed
+
+  const actual = events.join(" -> ")
+  const dataIndex = events.indexOf("data")
+  const closeIndex = events.indexOf("close")
+
+  assert(events[0] === "connect", `expected connect first, got ${actual}`)
+  assert(dataIndex > 0, `expected data after connect, got ${actual}`)
+  assert(closeIndex > dataIndex, `expected close after data, got ${actual}`)
+}

--- a/tools/with-echo/main.go
+++ b/tools/with-echo/main.go
@@ -70,7 +70,7 @@ func NewCommandRunner() (*CommandRunner, error) {
 // Run executes the specified command with arguments.
 func (cr *CommandRunner) Run(cmdName string, cmdArgs ...string) int {
 	ctx := context.Background()
-	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...) //#nosec G204
+	cmd := exec.CommandContext(ctx, cmdName, cmdArgs...) //#nosec G702,G204
 
 	// Connect stdin, stdout, stderr to preserve interactivity
 	cmd.Stdin = os.Stdin
@@ -83,7 +83,7 @@ func (cr *CommandRunner) Run(cmdName string, cmdArgs ...string) int {
 
 	// Start the command
 	if err := cmd.Start(); err != nil {
-		slog.Error("Failed to start command", "cmd", cmdName, "err", err)
+		slog.Error("Failed to start command", "cmd", cmdName, "err", err) //#nosec G706
 
 		return 1
 	}


### PR DESCRIPTION
## Summary
- make socket event dispatch ordering deterministic enough that connect cannot be overtaken by later lifecycle events
- queue socket event callbacks synchronously into the loop
- enqueue connect before starting the read goroutine
- remove the old destroy() sleep workaround made obsolete by ordered queueing
- add focused Go and JS regression coverage for lifecycle event order
- stabilize the connectAsync lifecycle test that became timing-sensitive after the ordering fix
- make embedded echo server setup fail fast with a clear error instead of a nil dereference