### PR TITLE
refactor: simplify runtime helpers

### DIFF
--- a/tcp/metrics.go
+++ b/tcp/metrics.go
@@ -1,7 +1,6 @@
 package tcp
 
 import (
-	"fmt"
 	"sort"
 
 	"go.k6.io/k6/js/modules"
@@ -48,11 +47,7 @@ func newTCPMetrics(vu modules.VU) *tcpMetrics {
 	}
 }
 
-func addToTagSet(ts *metrics.TagSet, tags map[string]string, nv ...string) *metrics.TagSet {
-	if len(nv)%2 != 0 {
-		panic(fmt.Errorf("%w: expected even number of tags", errWrongNumberOfArgs))
-	}
-
+func addToTagSet(ts *metrics.TagSet, tags map[string]string) *metrics.TagSet {
 	keys := make([]string, 0, len(tags))
 
 	for k := range tags {
@@ -63,10 +58,6 @@ func addToTagSet(ts *metrics.TagSet, tags map[string]string, nv ...string) *metr
 
 	for _, k := range keys {
 		ts = ts.With(k, tags[k])
-	}
-
-	for i := 0; i < len(nv); i += 2 {
-		ts = ts.With(nv[i], nv[i+1])
 	}
 
 	return ts

--- a/tcp/socket_connect.go
+++ b/tcp/socket_connect.go
@@ -32,24 +32,14 @@ func (s *socket) connect(portOrOptions sobek.Value, hostOrEmpty sobek.Value) (*s
 	promise, resolve, reject := promises.New(s.vu)
 
 	if err := s.connectPrepare(portOrOptions, hostOrEmpty); err != nil {
-		tcpErr := s.handleError(err, "connect", s.tags())
-		if tcpErr == nil {
-			tcpErr = newTCPError(err, "connect")
-		}
-
-		reject(tcpErr)
+		s.rejectWithTCPError(reject, err, "connect", s.tags())
 
 		return promise, nil
 	}
 
 	go func() {
 		if err := s.connectExecute(); err != nil {
-			tcpErr := s.handleError(err, "connect", s.tags())
-			if tcpErr == nil {
-				tcpErr = newTCPError(err, "connect")
-			}
-
-			reject(tcpErr)
+			s.rejectWithTCPError(reject, err, "connect", s.tags())
 
 			return
 		}

--- a/tcp/socket_loop.go
+++ b/tcp/socket_loop.go
@@ -2,7 +2,6 @@ package tcp
 
 import (
 	"context"
-	"log/slog"
 
 	"github.com/mstoykov/k6-taskqueue-lib/taskqueue"
 )
@@ -19,7 +18,7 @@ func (s *socket) loop(ctx context.Context) {
 		case call := <-s.callChan:
 			tq.Queue(call)
 		case <-ctx.Done():
-			slog.Debug("Socket context done, stopping event loop")
+			s.log.Debug("Socket context done, stopping event loop")
 
 			return
 		}

--- a/tcp/socket_metrics.go
+++ b/tcp/socket_metrics.go
@@ -1,14 +1,11 @@
 package tcp
 
 import (
-	"errors"
 	"strconv"
 	"time"
 
 	"go.k6.io/k6/metrics"
 )
-
-var errWrongNumberOfArgs = errors.New("wrong number of arguments")
 
 func (s *socket) currentTags() *metrics.TagSet {
 	return s.vu.State().Tags.GetCurrentValues().Tags
@@ -33,12 +30,12 @@ func (s *socket) tags() *metrics.TagSet {
 	return tags
 }
 
-func (s *socket) addErrorMetrics(ts *metrics.TagSet, nv ...string) {
+func (s *socket) addErrorMetrics(ts *metrics.TagSet) {
 	metrics.PushIfNotDone(s.vu.Context(), s.vu.State().Samples, metrics.Samples{
 		metrics.Sample{
 			TimeSeries: metrics.TimeSeries{
 				Metric: s.metrics.tcpErrors,
-				Tags:   addToTagSet(ts, nil, nv...),
+				Tags:   ts,
 			},
 			Time:  time.Now(),
 			Value: float64(1),

--- a/tcp/socket_on.go
+++ b/tcp/socket_on.go
@@ -106,6 +106,15 @@ func (s *socket) handleError(err error, method string, ts *metrics.TagSet) error
 	return wrapped
 }
 
+func (s *socket) rejectWithTCPError(reject func(any), err error, method string, ts *metrics.TagSet) {
+	tcpErr := s.handleError(err, method, ts)
+	if tcpErr == nil {
+		tcpErr = newTCPError(err, method)
+	}
+
+	reject(tcpErr)
+}
+
 // TCPError represents an error that occurred during a TCP operation.
 type TCPError struct { //nolint:revive
 	Name    string

--- a/tcp/socket_state.go
+++ b/tcp/socket_state.go
@@ -17,10 +17,7 @@ func (s *socket) readyState() string {
 }
 
 func (s *socket) isReadable() bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	return s.state == socketStateOpen
+	return s.isConnected()
 }
 
 func (s *socket) isConnected() bool {

--- a/tcp/socket_timeout.go
+++ b/tcp/socket_timeout.go
@@ -24,15 +24,14 @@ func (s *socket) setTimeout(timeoutMs int64) (*sobek.Object, error) {
 		s.log.WithField("timeout", s.timeout).Debug("Timeout set")
 	}
 
-	// If we have an active connection, update its deadline
-	if s.conn != nil && s.timeout > 0 {
-		deadline := time.Now().Add(s.timeout)
-		if err := s.conn.SetReadDeadline(deadline); err != nil {
-			return s.this, err
+	// If we have an active connection, update its deadline.
+	if s.conn != nil {
+		var deadline time.Time
+		if s.timeout > 0 {
+			deadline = time.Now().Add(s.timeout)
 		}
-	} else if s.conn != nil && s.timeout == 0 {
-		// Clear the deadline
-		if err := s.conn.SetReadDeadline(time.Time{}); err != nil {
+
+		if err := s.conn.SetReadDeadline(deadline); err != nil {
 			return s.this, err
 		}
 	}

--- a/tcp/socket_write.go
+++ b/tcp/socket_write.go
@@ -29,12 +29,7 @@ func (s *socket) write(data sobek.Value, opts *writeOptions) (*sobek.Promise, er
 
 	dataBytes, opts, err := s.writePrepare(data, opts)
 	if err != nil {
-		tcpErr := s.handleError(err, "write", addToTagSet(s.currentTags(), opts.Tags))
-		if tcpErr == nil {
-			tcpErr = newTCPError(err, "write")
-		}
-
-		reject(tcpErr)
+		s.rejectWithTCPError(reject, err, "write", addToTagSet(s.currentTags(), opts.Tags))
 
 		return promise, nil
 	}


### PR DESCRIPTION

## Summary

Closes #34.

This PR simplifies a few small runtime paths without changing public behavior.

- make `isReadable()` delegate to `isConnected()`
- remove dead variadic tag-helper plumbing and the unused sentinel around it
- collapse duplicated `setTimeout()` deadline handling
- extract the repeated Promise rejection fallback used by `connect()` and `write()`
- make socket loop shutdown logging use the same logger as the rest of the runtime