### PR TITLE
docs: draft v0.2.0 release notes

### DIFF
--- a/releases/v0.2.0.md
+++ b/releases/v0.2.0.md
@@ -1,0 +1,92 @@
+**xk6-tcp** `v0.2.0` is here 🎉!
+
+This release focuses on API cleanup, correctness fixes, and documentation improvements after the initial public release.
+
+**xk6-tcp** now provides a consistently async-first JavaScript API, improved runtime correctness, refreshed documentation, and a clearer upgrade path from the original public release.
+
+## Breaking Changes
+
+- The `data` event now delivers a `Uint8Array` instead of an `ArrayBuffer`.
+  Migration: update handlers that assumed `ArrayBuffer` input to consume `Uint8Array` directly.
+- The synchronous JavaScript socket APIs were removed from the public surface.
+  Migration: use the Promise-based API with `await socket.connect(...)` and `await socket.write(...)`.
+- The Promise-based methods were renamed to become the primary public names:
+  - `connectAsync()` -> `connect()`
+  - `writeAsync()` -> `write()`
+  Migration: rename existing method calls and continue awaiting the returned Promises.
+
+## Bug Fixes
+
+- `connect()` now rejects its Promise correctly on connection failures.
+- `write()` encoding handling now matches the documented behavior.
+- The read loop now stops cleanly on fatal read errors.
+- Socket event ordering is now deterministic.
+- The binary example script has been repaired.
+
+## New Capabilities
+
+- `write()` now supports the documented string encodings consistently:
+  - `utf8`
+  - `utf-8`
+  - `ascii`
+  - `base64`
+  - `base64url`
+  - `hex`
+
+## Documentation
+
+- `index.d.ts` is now aligned with the actual runtime behavior.
+- README, examples, and maintainer-facing docs were refreshed to match the current async-first API.
+
+## Dependency Updates
+
+- Updated `google.golang.org/grpc` to a patched release.
+- Updated `go.k6.io/k6` to `v1.7.1`.
+- Updated the OpenTelemetry dependencies used by the project tooling.
+
+## Internal
+
+- Simplified several runtime helper paths without changing public behavior.
+
+## Quick Start
+
+```javascript
+import { Socket } from "k6/x/tcp";
+
+export default async function () {
+  const socket = new Socket();
+
+  const closePromise = new Promise((resolve) => {
+    socket.on("close", resolve);
+  });
+
+  socket.on("data", (data) => {
+    const response = String.fromCharCode.apply(null, new Uint8Array(data));
+    console.log("Received:", response);
+    socket.destroy();
+  });
+
+  socket.on("error", (err) => {
+    console.error("Socket error:", err);
+  });
+
+  await socket.connect(8080, "localhost");
+  await socket.write("Hello, TCP!");
+  await closePromise;
+}
+```
+
+## Installation
+
+```bash
+xk6 build --with github.com/grafana/xk6-tcp@v0.2.0
+```
+
+## Maintainer Checklist
+
+The following steps happen after this PR merges:
+
+- Merge the remaining release-prep branch state to `main`
+- Create and push git tag `v0.2.0`
+- Publish the GitHub release using this file as the release body
+- Verify `xk6 build --with github.com/grafana/xk6-tcp@v0.2.0`

--- a/releases/v0.2.0.md
+++ b/releases/v0.2.0.md
@@ -82,11 +82,3 @@ export default async function () {
 xk6 build --with github.com/grafana/xk6-tcp@v0.2.0
 ```
 
-## Maintainer Checklist
-
-The following steps happen after this PR merges:
-
-- Merge the remaining release-prep branch state to `main`
-- Create and push git tag `v0.2.0`
-- Publish the GitHub release using this file as the release body
-- Verify `xk6 build --with github.com/grafana/xk6-tcp@v0.2.0`


### PR DESCRIPTION

## Summary

Closes #35.

This PR adds the draft `v0.2.0` release notes for `xk6-tcp`.

- add `releases/v0.2.0.md`
- summarize the full `v0.1.0` -> `v0.2.0` change set
- call out the breaking changes, fixes, new capabilities, documentation work, and dependency updates
- include an updated quick-start example and installation snippet for `@v0.2.0`