### PR TITLE
fix: pass current tags when handling read errors

### DIFF
--- a/tcp/socket_read.go
+++ b/tcp/socket_read.go
@@ -84,7 +84,7 @@ func (s *socket) readLoopStep(conn net.Conn, timeout time.Duration) bool {
 		return true
 	}
 
-	e := s.handleError(err, "read", nil)
+	e := s.handleError(err, "read", s.currentTags())
 	if e != nil {
 		s.log.WithError(e).Error("error in error handler")
 	}

--- a/tcp/socket_read_test.go
+++ b/tcp/socket_read_test.go
@@ -19,6 +19,16 @@ var errConnectionResetByPeer = errors.New("connection reset by peer")
 func newRunningModuleInstance(t *testing.T) *module {
 	t.Helper()
 
+	mod, _ := newRunningModuleInstanceWithSamples(t)
+
+	return mod
+}
+
+// newRunningModuleInstanceWithSamples also returns the sample channel, since lib.State
+// exposes it as send-only and tests cannot read back from it.
+func newRunningModuleInstanceWithSamples(t *testing.T) (*module, chan metrics.SampleContainer) {
+	t.Helper()
+
 	runtime := modulestest.NewRuntime(t)
 	root := new(rootModule)
 	moduleInstance := root.NewModuleInstance(runtime.VU)
@@ -28,13 +38,15 @@ func newRunningModuleInstance(t *testing.T) *module {
 		t.Fatalf("failed to assert module instance")
 	}
 
+	samples := make(chan metrics.SampleContainer, 1000)
+
 	registry := runtime.VU.InitEnvField.Registry
 	runtime.MoveToVUContext(&lib.State{
-		Samples: make(chan metrics.SampleContainer, 1000),
+		Samples: samples,
 		Tags:    lib.NewVUStateTags(registry.RootTagSet()),
 	})
 
-	return mod
+	return mod, samples
 }
 
 type stubConn struct {
@@ -64,6 +76,33 @@ func TestReadLoopStepFatalErrorReturnsFalse(t *testing.T) {
 
 	conn := &stubConn{readErr: errConnectionResetByPeer}
 	require.False(t, s.readLoopStep(conn, 0))
+}
+
+// A read error must emit its tcp_errors sample with a non-nil TagSet. k6's outputs call
+// Tags.Get on every sample during the periodic metric flush, so a nil TagSet panics the
+// flusher goroutine and takes down the whole test run.
+func TestReadLoopStepFatalErrorPushesTaggedSample(t *testing.T) {
+	t.Parallel()
+
+	mod, samples := newRunningModuleInstanceWithSamples(t)
+	s := newSocket(mod.log, mod.vu, mod.metrics)
+	_, cancel := context.WithCancel(mod.vu.Context())
+	s.cancel = cancel
+	s.state = socketStateOpen
+
+	conn := &stubConn{readErr: errConnectionResetByPeer}
+	require.False(t, s.readLoopStep(conn, 0))
+
+	require.Len(t, samples, 1)
+
+	emitted := (<-samples).GetSamples()
+	require.Len(t, emitted, 1)
+	require.Equal(t, tcpErrors, emitted[0].Metric.Name)
+	require.NotNil(t, emitted[0].Tags)
+
+	// mirrors what k6's summary output does with every flushed sample
+	_, hasCheckTag := emitted[0].Tags.Get(metrics.TagCheck.String())
+	require.False(t, hasCheckTag)
 }
 
 func TestReadLoopStepEOFReturnsFalse(t *testing.T) {


### PR DESCRIPTION
Fixes #67

## What this fixes

A non-EOF, non-timeout read error pushed its `tcp_errors` sample with a `nil` `*metrics.TagSet`. k6's summary output calls `sample.Tags.Get(...)` on every sample during its periodic flush (every 200ms, on its own goroutine), so the `nil` set caused a nil pointer dereference that killed the whole test run — with no `xk6-tcp` frames anywhere in the stack trace.

Reported and diagnosed by [@bernda01](https://community.grafana.com/u/bernda01) on the [Grafana Community forum](https://community.grafana.com/t/cannot-create-an-issue-in-github-to-report-bug-for-k6-or-xk6-tcp/164042).

## The fix

`tcp/socket_read.go`:

```diff
-	e := s.handleError(err, "read", nil)
+	e := s.handleError(err, "read", s.currentTags())
```

This matches the read-*success* path at `socket_read.go:45`, which already uses `s.currentTags()`.

## Regression test

`TestReadLoopStepFatalErrorPushesTaggedSample` drives `readLoopStep` into a `connection reset by peer` error and asserts the emitted sample is `tcp_errors` with non-`nil` `Tags`. It then calls `Tags.Get(metrics.TagCheck.String())` to mirror exactly what k6's summary output does with each flushed sample.

Confirmed to **fail** without the one-line fix (`Expected value not to be nil`), so it is not vacuous.

One test-helper change was needed to make this assertable: `lib.State.Samples` is typed `chan<-` (send-only), so a test cannot read back what was pushed. `newRunningModuleInstance` is split into `newRunningModuleInstanceWithSamples`, which returns both the module and the bidirectional channel; `newRunningModuleInstance` delegates to it, so the three existing call sites are unchanged.

